### PR TITLE
workaround for parsing private key error

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,12 @@ dependencies {
 
     compile "org.embulk:embulk-util-file:0.1.3"
     compile "org.embulk:embulk-util-config:0.3.2"
-    compile 'com.box:box-java-sdk:4.0.0'
+    implementation('com.box:box-java-sdk:4.0.0') {
+        exclude group: 'org.bouncycastle', module: 'bcprov-jdk15on'
+        exclude group: 'org.bouncycastle', module: 'bcpkix-jdk15on'
+    }
+    runtimeOnly('org.bouncycastle:bcprov-jdk15on:1.70')
+    runtimeOnly('org.bouncycastle:bcpkix-jdk15on:1.70')
     testCompile "junit:junit:4.+"
 }
 

--- a/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -12,8 +12,9 @@ com.squareup.okio:okio-jvm:3.0.0
 com.squareup.okio:okio:3.0.0
 javax.validation:validation-api:1.1.0.Final
 org.bitbucket.b_c:jose4j:0.9.0
-org.bouncycastle:bcpkix-jdk15on:1.57
-org.bouncycastle:bcprov-jdk15on:1.57
+org.bouncycastle:bcpkix-jdk15on:1.70
+org.bouncycastle:bcprov-jdk15on:1.70
+org.bouncycastle:bcutil-jdk15on:1.70
 org.embulk:embulk-util-config:0.3.2
 org.embulk:embulk-util-file:0.1.3
 org.jetbrains.kotlin:kotlin-stdlib-common:1.6.20


### PR DESCRIPTION
An error is hppened when auth_method is jwt which has been revently generated.

```
Loading Java Agent version 1 (using ASM9).
2024-01-05 02:48:30.760 +0000: Embulk v0.9.26
2024-01-05 02:48:31.359 +0000 [WARN] (main): DEPRECATION: JRuby org.jruby.embed.ScriptingContainer is directly injected.
2024-01-05 02:48:33.082 +0000 [INFO] (main): BUNDLE_GEMFILE is being set: "/work/embulk_bundle/Gemfile"
2024-01-05 02:48:33.082 +0000 [INFO] (main): Gem's home and path are being cleared.
2024-01-05 02:48:36.061 +0000 [INFO] (main): Started Embulk v0.9.26
2024-01-05 02:48:36.252 +0000 [INFO] (0001:guess): Loaded plugin embulk-input-box (0.2.0)
2024-01-05 02:48:36.342 +0000 [INFO] (0001:guess): Try to read 10,485,760 bytes from input source
2024-01-05 02:48:36.697 +0000 [ERROR] (0001:guess): Error parsing private key for Box Developer Edition.
com.box.sdk.BoxAPIException: Error parsing private key for Box Developer Edition.
	at com.box.sdk.BoxDeveloperEditionAPIConnection.decryptPrivateKey(BoxDeveloperEditionAPIConnection.java:564) ~[na:na]
	at com.box.sdk.BoxDeveloperEditionAPIConnection.constructJWTAssertion(BoxDeveloperEditionAPIConnection.java:503) ~[na:na]
	at com.box.sdk.BoxDeveloperEditionAPIConnection.authenticate(BoxDeveloperEditionAPIConnection.java:327) ~[na:na]
	at com.box.sdk.BoxDeveloperEditionAPIConnection.getAppEnterpriseConnection(BoxDeveloperEditionAPIConnection.java:182) ~[na:na]
	at com.box.sdk.BoxDeveloperEditionAPIConnection.getAppEnterpriseConnection(BoxDeveloperEditionAPIConnection.java:216) ~[na:na]
	at org.embulk.input.box.BoxClient.<init>(BoxClient.java:34) ~[na:na]
	at org.embulk.input.box.BoxFileInputPlugin.open(BoxFileInputPlugin.java:43) [embulk-input-box-0.2.0.jar:0.2.0]
	at org.embulk.spi.FileInputRunner.run(FileInputRunner.java:135) [embulk:0.9.26]
	at org.embulk.exec.SamplingParserPlugin$1.run(SamplingParserPlugin.java:56) [embulk:0.9.26]
```

Please refer the following about the workaround.
- https://github.com/box/box-java-sdk/issues/1217
- https://github.com/box/box-java-sdk?tab=readme-ov-file#fips-140-2-compliance
