### PR TITLE
support-stop-when-file-not-found

### DIFF
--- a/src/main/java/org/embulk/input/box/BoxClient.java
+++ b/src/main/java/org/embulk/input/box/BoxClient.java
@@ -1,16 +1,5 @@
 package org.embulk.input.box;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.StringReader;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.List;
-
-import org.embulk.config.ConfigException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.box.sdk.BoxAPIConnection;
 import com.box.sdk.BoxAPIRequest;
 import com.box.sdk.BoxAPIResponse;
@@ -19,6 +8,15 @@ import com.box.sdk.BoxDeveloperEditionAPIConnection;
 import com.box.sdk.BoxFile;
 import com.box.sdk.BoxFolder;
 import com.box.sdk.BoxItem;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringReader;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import org.embulk.config.ConfigException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class BoxClient {
   private final Logger logger = LoggerFactory.getLogger(BoxClient.class);
@@ -67,7 +65,8 @@ public class BoxClient {
     logger.info(String.format("total files %d", list.size()));
 
     if (list.isEmpty() && pluginTask.getStopWhenFileNotFound()) {
-      throw new ConfigException("No file is found. \"stop_when_file_not_found\" option is \"true\".");
+      throw new ConfigException(
+          "No file is found. \"stop_when_file_not_found\" option is \"true\".");
     }
 
     return list;

--- a/src/main/java/org/embulk/input/box/BoxClient.java
+++ b/src/main/java/org/embulk/input/box/BoxClient.java
@@ -1,5 +1,16 @@
 package org.embulk.input.box;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringReader;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.embulk.config.ConfigException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.box.sdk.BoxAPIConnection;
 import com.box.sdk.BoxAPIRequest;
 import com.box.sdk.BoxAPIResponse;
@@ -8,15 +19,6 @@ import com.box.sdk.BoxDeveloperEditionAPIConnection;
 import com.box.sdk.BoxFile;
 import com.box.sdk.BoxFolder;
 import com.box.sdk.BoxItem;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.StringReader;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.List;
-import org.embulk.config.ConfigException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class BoxClient {
   private final Logger logger = LoggerFactory.getLogger(BoxClient.class);
@@ -63,6 +65,11 @@ public class BoxClient {
       }
     }
     logger.info(String.format("total files %d", list.size()));
+
+    if (list.isEmpty() && pluginTask.getStopWhenFileNotFound()) {
+      throw new ConfigException("No file is found. \"stop_when_file_not_found\" option is \"true\".");
+    }
+
     return list;
   }
 

--- a/src/main/java/org/embulk/input/box/PluginTask.java
+++ b/src/main/java/org/embulk/input/box/PluginTask.java
@@ -1,7 +1,6 @@
 package org.embulk.input.box;
 
 import java.util.Optional;
-
 import org.embulk.util.config.Config;
 import org.embulk.util.config.ConfigDefault;
 import org.embulk.util.config.Task;

--- a/src/main/java/org/embulk/input/box/PluginTask.java
+++ b/src/main/java/org/embulk/input/box/PluginTask.java
@@ -1,6 +1,7 @@
 package org.embulk.input.box;
 
 import java.util.Optional;
+
 import org.embulk.util.config.Config;
 import org.embulk.util.config.ConfigDefault;
 import org.embulk.util.config.Task;
@@ -24,4 +25,8 @@ public interface PluginTask extends Task {
   @Config("file_prefix")
   @ConfigDefault("null")
   Optional<String> getFilePrefix();
+
+  @Config("stop_when_file_not_found")
+  @ConfigDefault("false")
+  boolean getStopWhenFileNotFound();
 }


### PR DESCRIPTION
- ref: https://github.com/primenumber-dev/n-transfer-ui/issues/15720  
- Support `stop_when_file_not_found` option.  
  When set to `true`, the plugin checks for the existence of all files and stops if any are missing.  
  (Type: boolean, default: `false`)
