### PR TITLE
bump box-java-sdk from 4.16.1 to 5.4.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
 
     compile "org.embulk:embulk-util-file:0.1.3"
     compile "org.embulk:embulk-util-config:0.3.2"
-    implementation('com.box:box-java-sdk:4.16.1') {
+    implementation('com.box:box-java-sdk:5.4.0') {
         exclude group: 'org.bouncycastle', module: 'bcprov-jdk15on'
         exclude group: 'org.bouncycastle', module: 'bcpkix-jdk15on'
     }

--- a/gradle/dependency-locks/compileClasspath.lockfile
+++ b/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,7 +1,7 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.box:box-java-sdk:4.16.1
+com.box:box-java-sdk:5.4.0
 org.embulk:embulk-api:0.10.42
 org.embulk:embulk-spi:0.10.42
 org.embulk:embulk-util-config:0.3.2

--- a/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -1,24 +1,25 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
-com.box:box-java-sdk:4.16.1
+com.box:box-java-sdk:5.4.0
 com.eclipsesource.minimal-json:minimal-json:0.9.5
-com.fasterxml.jackson.core:jackson-annotations:2.6.7
-com.fasterxml.jackson.core:jackson-core:2.6.7
-com.fasterxml.jackson.core:jackson-databind:2.6.7
-com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
+com.fasterxml.jackson.core:jackson-annotations:2.18.2
+com.fasterxml.jackson.core:jackson-core:2.18.2
+com.fasterxml.jackson.core:jackson-databind:2.18.2
+com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.18.2
+com.fasterxml.jackson:jackson-bom:2.18.2
 com.github.luben:zstd-jni:1.5.7-2
 com.squareup.okhttp3:okhttp:4.12.0
 com.squareup.okio:okio-jvm:3.6.0
 com.squareup.okio:okio:3.6.0
 javax.validation:validation-api:1.1.0.Final
-org.bitbucket.b_c:jose4j:0.9.4
+org.bitbucket.b_c:jose4j:0.9.6
 org.bouncycastle:bcpkix-jdk15on:1.70
-org.bouncycastle:bcpkix-jdk18on:1.78.1
+org.bouncycastle:bcpkix-jdk18on:1.82
 org.bouncycastle:bcprov-jdk15on:1.70
-org.bouncycastle:bcprov-jdk18on:1.78.1
+org.bouncycastle:bcprov-jdk18on:1.82
 org.bouncycastle:bcutil-jdk15on:1.70
-org.bouncycastle:bcutil-jdk18on:1.78.1
+org.bouncycastle:bcutil-jdk18on:1.82
 org.embulk:embulk-util-config:0.3.2
 org.embulk:embulk-util-file:0.1.3
 org.jetbrains.kotlin:kotlin-stdlib-common:1.9.10


### PR DESCRIPTION
## Summary
- Upgrade box-java-sdk from 4.16.1 to 5.4.0
- No breaking changes in `com.box.sdk` package between v4 and v5
- Update dependency lock files

## Test plan
- [x] `./gradlew build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)