### PR TITLE
Add maximum_retries config to limit BOX API retry duration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,8 @@ dependencies {
     runtimeOnly('org.bouncycastle:bcprov-jdk15on:1.70')
     runtimeOnly('org.bouncycastle:bcpkix-jdk15on:1.70')
     testCompile "junit:junit:4.+"
+    testCompile "org.embulk:embulk-api:${embulkVersion}"
+    testCompile "org.embulk:embulk-spi:${embulkVersion}"
 }
 
 embulkPlugin {

--- a/src/main/java/org/embulk/input/box/BoxClient.java
+++ b/src/main/java/org/embulk/input/box/BoxClient.java
@@ -36,6 +36,7 @@ public class BoxClient {
       } else {
         throw new ConfigException("auth_method: " + authMethod + " is not allowd");
       }
+      client.setMaxRetryAttempts(pluginTask.getMaximumRetries());
       this.pluginTask = pluginTask;
     } catch (IOException e) {
       logger.error(e.getMessage(), e);

--- a/src/main/java/org/embulk/input/box/PluginTask.java
+++ b/src/main/java/org/embulk/input/box/PluginTask.java
@@ -28,4 +28,8 @@ public interface PluginTask extends Task {
   @Config("stop_when_file_not_found")
   @ConfigDefault("false")
   boolean getStopWhenFileNotFound();
+
+  @Config("maximum_retries")
+  @ConfigDefault("3")
+  int getMaximumRetries();
 }

--- a/src/test/java/org/embulk/input/box/TestBoxFileInputPlugin.java
+++ b/src/test/java/org/embulk/input/box/TestBoxFileInputPlugin.java
@@ -1,3 +1,57 @@
 package org.embulk.input.box;
 
-public class TestBoxFileInputPlugin {}
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.embulk.config.ConfigSource;
+import org.embulk.util.config.ConfigMapper;
+import org.embulk.util.config.ConfigMapperFactory;
+import org.junit.Test;
+
+public class TestBoxFileInputPlugin {
+  private static final ConfigMapperFactory CONFIG_MAPPER_FACTORY =
+      ConfigMapperFactory.builder().addDefaultModules().build();
+  private static final ConfigMapper CONFIG_MAPPER = CONFIG_MAPPER_FACTORY.createConfigMapper();
+
+  private ConfigSource baseJwtConfig() {
+    return CONFIG_MAPPER_FACTORY
+        .newConfigSource()
+        .set("auth_method", "jwt")
+        .set("json_config", "{}")
+        .set("folder_id", "1234");
+  }
+
+  @Test
+  public void maximum_retries_defaults_to_3() {
+    PluginTask task = CONFIG_MAPPER.map(baseJwtConfig(), PluginTask.class);
+    assertEquals(3, task.getMaximumRetries());
+  }
+
+  @Test
+  public void maximum_retries_accepts_explicit_value() {
+    PluginTask task =
+        CONFIG_MAPPER.map(baseJwtConfig().set("maximum_retries", 10), PluginTask.class);
+    assertEquals(10, task.getMaximumRetries());
+  }
+
+  @Test
+  public void maximum_retries_accepts_zero() {
+    PluginTask task =
+        CONFIG_MAPPER.map(baseJwtConfig().set("maximum_retries", 0), PluginTask.class);
+    assertEquals(0, task.getMaximumRetries());
+  }
+
+  @Test
+  public void stop_when_file_not_found_defaults_to_false() {
+    PluginTask task = CONFIG_MAPPER.map(baseJwtConfig(), PluginTask.class);
+    assertFalse(task.getStopWhenFileNotFound());
+  }
+
+  @Test
+  public void stop_when_file_not_found_can_be_true() {
+    PluginTask task =
+        CONFIG_MAPPER.map(baseJwtConfig().set("stop_when_file_not_found", true), PluginTask.class);
+    assertTrue(task.getStopWhenFileNotFound());
+  }
+}


### PR DESCRIPTION
## Summary

- Add `maximum_retries` config option (default: 3) and apply it via `BoxAPIConnection.setMaxRetryAttempts()` so users can cap the number of retry attempts.
- Addresses a long-running job issue where the BOX SDK respects the `Retry-After` header (up to 6 days) on rate-limited (HTTP 429) responses and keeps retrying.
- Add unit tests for the config mapping (default value, explicit value, and zero).


## Test plan

- [x] `./gradlew test` — all unit tests pass (5 tests, 0 failures)